### PR TITLE
fix: use correct endpoint for timeslots

### DIFF
--- a/source/js/services/BookingService.ts
+++ b/source/js/services/BookingService.ts
@@ -118,7 +118,7 @@ const getHistoricalAttendees = async (referenceCode: string, startTime: string, 
 };
 
 const getTimeSlots = async (attendees: string[], startTime: string, endTime: string): Promise<TimeSlotDataType> => {
-  const response = await post(`/timeslots/getTimeSlots`, {
+  const response = await post(`/booking/getTimeSlots`, {
     attendees,
     startTime,
     endTime,


### PR DESCRIPTION
This is a small fix to booking service so it uses the correct endpoint once https://github.com/helsingborg-stad/helsingborg-io-sls-api/pull/351 is merged.