### PR TITLE
fix: randomize organizer

### DIFF
--- a/source/js/helpers/BookingHelper.ts
+++ b/source/js/helpers/BookingHelper.ts
@@ -116,9 +116,15 @@ const formatTimePeriod = (dateString: string, startTime: string, endTime: string
   return `${startTimeString}-${endTimeString}`;
 };
 
+const randomNumberFromInterval = (min: number, max: number) => {
+  return Math.floor(Math.random() * (max - min + 1) + min);
+};
+
 const buildBookingRequest = (timeSlot: TimeSlot, formData: FormData): BookingRequest => {
+  const randomOrganizationRequiredAttendee = timeSlot.emails[randomNumberFromInterval(0, timeSlot.emails.length - 1)];
+
   return {
-    organizationRequiredAttendees: [...timeSlot.emails],
+    organizationRequiredAttendees: [randomOrganizationRequiredAttendee],
     externalRequiredAttendees: [formData.email.value],
     date: timeSlot.date,
     endTime: `${timeSlot.date}T${timeSlot.endTime}`,

--- a/source/js/helpers/__tests__/BookingHelper.ts
+++ b/source/js/helpers/__tests__/BookingHelper.ts
@@ -1,7 +1,136 @@
-import { formatTimePeriod } from '../BookingHelper';
+import { TimeSlot, FormData } from '../../types/BookingTypes';
+import { formatTimePeriod, consolidateTimeSlots, buildBookingRequest } from '../BookingHelper';
 
-it('returns time period in hours and minutes', () => {
-  const period = formatTimePeriod('2022-03-10', '07:00:00+01:00', '08:00:00+01:00');
+const formData: FormData = {
+  firstname: {
+    value: 'firstname',
+    name: 'Förnamn',
+  },
+  lastname: {
+    value: 'lastname',
+    name: 'Efternamn',
+  },
+  email: {
+    value: 'user@email.com',
+    name: 'Email',
+  },
+  phone: {
+    value: '123',
+    name: 'Telefon',
+  },
+  comment: {
+    value: 'comment',
+    name: 'Övrigt',
+  },
+  remoteMeeting: {
+    value: false,
+    name: 'Jag vill ansluta digitalt',
+  },
+};
 
-  expect(period).toBe('07:00-08:00');
+describe('formatTimePeriod', () => {
+  it('returns time period in hours and minutes', () => {
+    const period = formatTimePeriod('2022-03-10', '07:00:00+01:00', '08:00:00+01:00');
+
+    expect(period).toBe('07:00-08:00');
+  });
+});
+
+describe('consolidateTimeSlots', () => {
+  it('merges user timeslots into a common data structure', () => {
+    const timeSlots = {
+      'email@email.com': {
+        '2022-03-16': [
+          {
+            startTime: '07:00:0000:00',
+            endTime: '08:00:0000:00',
+          },
+        ],
+        '2022-03-17': [
+          {
+            startTime: '07:00:0000:00',
+            endTime: '08:00:0000:00',
+          },
+        ],
+      },
+      'email2@email.com': {
+        '2022-03-16': [
+          {
+            startTime: '07:00:0000:00',
+            endTime: '08:00:0000:00',
+          },
+        ],
+      },
+    };
+
+    const period = consolidateTimeSlots(timeSlots);
+
+    expect(period).toEqual({
+      '2022-03-16': [
+        {
+          date: '2022-03-16',
+          emails: ['email@email.com', 'email2@email.com'],
+          endTime: '08:00:0000:00',
+          startTime: '07:00:0000:00',
+        },
+      ],
+      '2022-03-17': [
+        {
+          date: '2022-03-17',
+          emails: ['email@email.com'],
+          endTime: '08:00:0000:00',
+          startTime: '07:00:0000:00',
+        },
+      ],
+    });
+  });
+});
+
+describe('buildBookingRequest', () => {
+  it('maps formdata to booking request body', () => {
+    const timeSlot: TimeSlot = {
+      date: '2022-03-17',
+      startTime: '07:00:0000:00',
+      endTime: '08:00:0000:00',
+      emails: ['email@email.com'],
+    };
+
+    const bookingRequest = buildBookingRequest(timeSlot, formData);
+
+    expect(bookingRequest).toEqual({
+      date: '2022-03-17',
+      endTime: '2022-03-17T08:00:0000:00',
+      externalRequiredAttendees: ['user@email.com'],
+      formData: {
+        comment: {
+          name: 'Övrigt',
+          value: 'comment',
+        },
+        email: {
+          name: 'Email',
+          value: 'user@email.com',
+        },
+        firstname: {
+          name: 'Förnamn',
+          value: 'firstname',
+        },
+        lastname: {
+          name: 'Efternamn',
+          value: 'lastname',
+        },
+        phone: {
+          name: 'Telefon',
+          value: '123',
+        },
+        remoteMeeting: {
+          name: 'Jag vill ansluta digitalt',
+          value: false,
+        },
+      },
+      organizationRequiredAttendees: ['email@email.com'],
+      remoteMeeting: false,
+      startTime: '2022-03-17T07:00:0000:00',
+      subject: 'Volontärsamtal',
+    });
+  });
 });


### PR DESCRIPTION
## Explain the changes you’ve made

Randomize organizer before booking request is submitted.

## Explain why these changes are made

Current implementation includes all available organizers when form is submitted.

## Explain your solution 

Select one random organizer from the list of available organizers when building the booking request. 

## How to test
1. Make sure there is multiple organizers available for a specific date and time.
2. Perform a form submit with the specific date and time.
3. Check that only one organizer is in booking request body.
4. Delete the booking from outlook and repeat step 2 until you recive a diffrent organizer email.

## Tested environments

- [X] Your local environment.
- [] Staging environment.

## Screenshots

N/A